### PR TITLE
Update python_version 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/googlevault.json
+++ b/googlevault.json
@@ -11,7 +11,7 @@
     "publisher": "Splunk",
     "license": "Copyright (c) 2019-2025 Splunk Inc.",
     "app_version": "2.1.2",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "utctime_updated": "2025-05-13T15:52:19.070206Z",
     "package_name": "phantom_googlevault",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13-2.0`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13-2.0)